### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,5 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@goanpeca](https://github.com/goanpeca/)
 * [@guiwitz](https://github.com/guiwitz/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,5 +46,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - goanpeca
     - guiwitz


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #3